### PR TITLE
docs: Update links (bdew-mako instead of edi@energy); Add link to edi-energy-scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-edi-energy-extractor
-====================
+# edi-energy-extractor
 
-A tool to semi-automatic extract all edi documents from the [edi-energy.de][edienergy] website.
+A C# tool to semi-automatic extract all edi documents from the [bdew-mako.de][bdewmako] website/API into a RavenDB.
 
-See also the [edienergyviewer][edienergyviewer] app which is a web frontend to browse the extracted data.
+## See also
+See also the [edi-energy-viewer][edienergyviewer] app which is a web frontend to browse the extracted data.
 
-[edienergy]: https://www.edi-energy.de
+For a Python and file-based tool with a similar purpose see [edi-energy-scraper](https://github.com/Hochfrequenz/edi_energy_scraper).
+
+[bdewmako]: https://www.bdew-mako.de
 [edienergyviewer]: https://github.com/fabsenet/edi-energy-viewer


### PR DESCRIPTION
I hope you don't consider this link spamming ;)
I added a link to this project in the edi-energy-scraper README, too: https://github.com/Hochfrequenz/edi_energy_scraper?tab=readme-ov-file#see-also

It's just good to see, that others struggle with the same issues, like e.g. reading data from an API which, at first glance, looks like a real step forward... "How hard could it possibly be?" 

Until you realize, we're back where we came from: Analyzing arbitrary file names and trying to make sense of PDF+word file metadata again, just like on good old edi-energy.de but this time additionally with duplicates, inconsistent timestamps and timezones and with misleading flags in the API response that are just plain wrong.